### PR TITLE
Checkout source repo submodules recusrively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           repository: SAGARobotics/${{ github.event.repository.name }}
           token: ${{ secrets.pat-token }}
-          submodules: true
+          submodules: recursive
           path: repository
 
       - name: Conform


### PR DESCRIPTION
We need to recursively checkout submodules in the workflow. Otherwise it breaks SagaSensors, which in turn will break ThorvaldAutonomy down the line.

https://github.com/SAGARobotics/ThorvaldSensors/actions/runs/3935443490/jobs/6731131175